### PR TITLE
Adds type definition to event to avoid compiler errors

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,11 @@
-import { Actor, CollisionType, Color, Engine, vec } from "excalibur";
+import {
+  Actor,
+  CollisionStartEvent,
+  CollisionType,
+  Color,
+  Engine,
+  vec,
+} from "excalibur";
 // game.js
 
 // start-snippet{create-engine}
@@ -135,7 +142,7 @@ bricks.forEach(function (brick) {
 // start-snippet{ball-brick-collision}
 // On collision remove the brick, bounce the ball
 let colliding = false;
-ball.on("collisionstart", function (ev) {
+ball.on("collisionstart", function (ev: CollisionStartEvent) {
   if (bricks.indexOf(ev.other) > -1) {
     // kill removes an actor from the current scene
     // therefore it will no longer be drawn or updated


### PR DESCRIPTION
This was a very minor thing I noticed, didn't think opening an issue would be needed for something so small. I'm happy to go do so if that's still required.

I was going through the "getting started" tutorial while doing everything inside an Angular project with strict typing set to false. I noticed that this specific event was defaulting to the GameEvent type in my compiler, resulting in a compiler error when trying to access the contact property.  

## Changes:

I could see this easily tripping up someone who might not know what's going on so I've just added explicit typing. 
